### PR TITLE
Feat 소셜 회원가입후 추가 데이터 입력 API 구현

### DIFF
--- a/src/main/java/com/swyp/meetup/controller/ImageController.java
+++ b/src/main/java/com/swyp/meetup/controller/ImageController.java
@@ -1,0 +1,34 @@
+package com.swyp.meetup.controller;
+
+import com.swyp.meetup.common.api.Api;
+import com.swyp.meetup.domain.image.ImageCode;
+import com.swyp.meetup.service.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PatchMapping("/images")
+    public ResponseEntity<?> updateImages(
+            Authentication authentication,
+            @RequestParam(value = "profileImage",required = false) MultipartFile profileImage,
+            @RequestParam("styleImage") List<MultipartFile> fashionImages
+    ) {
+        Long memberId = Long.valueOf((String) authentication.getPrincipal());
+
+        imageService.saveImages(memberId, profileImage, fashionImages);
+
+        return ResponseEntity.ok()
+                .body(Api.response(ImageCode.SUCCESS_IMAGE_STORED));
+    }
+}

--- a/src/main/java/com/swyp/meetup/controller/MemberController.java
+++ b/src/main/java/com/swyp/meetup/controller/MemberController.java
@@ -1,0 +1,42 @@
+package com.swyp.meetup.controller;
+
+import com.swyp.meetup.common.api.Api;
+import com.swyp.meetup.common.api.ResponseCode;
+import com.swyp.meetup.domain.member.MemberCode;
+import com.swyp.meetup.domain.member.dto.RestInfo;
+import com.swyp.meetup.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class MemberController {
+
+    private final MemberService memberService;
+
+
+    @GetMapping("/nickname/check")
+    public ResponseEntity<?> checkNickname(
+            @RequestParam String nickname
+    ) {
+        boolean existsNickname = memberService.checkNickname(nickname);
+        ResponseCode responseCode = (existsNickname)?MemberCode.ALREADY_USE_NICKNAME : MemberCode.NOT_USE_NICKNAME;
+        return ResponseEntity.ok()
+                .body(Api.response(responseCode));
+    }
+
+    @PatchMapping("/members")
+    public ResponseEntity<?> updateTextInfo(
+            Authentication authentication,
+            @RequestBody RestInfo restInfo
+    ) {
+        Long memberId = Long.valueOf((String) authentication.getPrincipal());
+        memberService.updateRestInfo(memberId, restInfo);
+        return ResponseEntity.ok()
+                .body(Api.response(MemberCode.TEXT_INFO_UPDATE_SUCCESS));
+    }
+}

--- a/src/main/java/com/swyp/meetup/domain/image/ImageCode.java
+++ b/src/main/java/com/swyp/meetup/domain/image/ImageCode.java
@@ -1,0 +1,21 @@
+package com.swyp.meetup.domain.image;
+
+import com.swyp.meetup.common.api.ResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ImageCode implements ResponseCode {
+
+    PROFILE_IMAGE_ESSENTIAL(400, "BAD REQUEST", "프로필 이미지는 필수 입력 값입니다."),
+    NOT_ENOUGH_IMAGE(400, "BAD REQUEST", "패션이미지는 3개 이상 입력해야합니다."),
+    NOT_EXISTS_FILE(400, "BAD REQUEST","파일이 존재하지 않습니다."),
+    NOT_MATCH_EXTENSION(400,"BAD REQUEST","이미지 외의 다른 파일 업로드는 불가능합니다."),
+    SUCCESS_IMAGE_STORED(200,"OK","이미지가 저장되었습니다.")
+    ;
+
+    private int code;
+    private String status;
+    private String message;
+}

--- a/src/main/java/com/swyp/meetup/domain/member/Member.java
+++ b/src/main/java/com/swyp/meetup/domain/member/Member.java
@@ -19,7 +19,7 @@ public class Member {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 50)
+    @Column(length = 50) @Setter
     private String nickname;
 
     @Column(length = 100, nullable = false)

--- a/src/main/java/com/swyp/meetup/domain/member/MemberCode.java
+++ b/src/main/java/com/swyp/meetup/domain/member/MemberCode.java
@@ -1,0 +1,19 @@
+package com.swyp.meetup.domain.member;
+
+import com.swyp.meetup.common.api.ResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum MemberCode implements ResponseCode {
+    NOT_FOUND(400,"BAD REQUEST","회원 정보를 찾을 수 없습니다. 다시 시도해주세요"),
+    ALREADY_USE_NICKNAME(200,"OK","존재하는 닉네임입니다."),
+    NOT_USE_NICKNAME(200,"OK","사용가능한 닉네임입니다."),
+    TEXT_INFO_UPDATE_SUCCESS(200,"OK","회원 정보를 성공적으로 수정했습니다.");
+
+
+    private int code;
+    private String status;
+    private String message;
+}

--- a/src/main/java/com/swyp/meetup/domain/member/MemberTagMap.java
+++ b/src/main/java/com/swyp/meetup/domain/member/MemberTagMap.java
@@ -1,8 +1,8 @@
 package com.swyp.meetup.domain.member;
 
-import com.swyp.meetup.domain.member.MemberTagId;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -11,5 +11,9 @@ import lombok.NoArgsConstructor;
 public class MemberTagMap {
     @EmbeddedId
     private MemberTagId id;
+
+    public static MemberTagMap from(Long memberId, Long styleTagId){
+        return new MemberTagMap(new MemberTagId(memberId, styleTagId));
+    }
 
 }

--- a/src/main/java/com/swyp/meetup/domain/member/dto/RestInfo.java
+++ b/src/main/java/com/swyp/meetup/domain/member/dto/RestInfo.java
@@ -1,0 +1,9 @@
+package com.swyp.meetup.domain.member.dto;
+
+import java.util.List;
+
+public record RestInfo(
+        String nickname,
+        List<Long> styleTagList
+) {
+}

--- a/src/main/java/com/swyp/meetup/repository/ImageRepository.java
+++ b/src/main/java/com/swyp/meetup/repository/ImageRepository.java
@@ -1,0 +1,7 @@
+package com.swyp.meetup.repository;
+
+import com.swyp.meetup.domain.image.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/src/main/java/com/swyp/meetup/repository/MemberRepository.java
+++ b/src/main/java/com/swyp/meetup/repository/MemberRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
+    Boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/swyp/meetup/repository/MemberTagMapRepository.java
+++ b/src/main/java/com/swyp/meetup/repository/MemberTagMapRepository.java
@@ -1,0 +1,9 @@
+package com.swyp.meetup.repository;
+
+import com.swyp.meetup.domain.member.MemberTagId;
+import com.swyp.meetup.domain.member.MemberTagMap;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberTagMapRepository extends JpaRepository<MemberTagMap, MemberTagId> {
+    void deleteAllById_MemberId(Long memberId);
+}

--- a/src/main/java/com/swyp/meetup/service/ImageService.java
+++ b/src/main/java/com/swyp/meetup/service/ImageService.java
@@ -1,0 +1,9 @@
+package com.swyp.meetup.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface ImageService {
+    void saveImages(Long memberId, MultipartFile profileImage, List<MultipartFile> fashionImages);
+}

--- a/src/main/java/com/swyp/meetup/service/MemberService.java
+++ b/src/main/java/com/swyp/meetup/service/MemberService.java
@@ -1,0 +1,13 @@
+package com.swyp.meetup.service;
+
+import com.swyp.meetup.domain.member.dto.RestInfo;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface MemberService {
+
+    boolean checkNickname(String nickname);
+
+    void updateRestInfo(Long memberId, RestInfo restInfo);
+}

--- a/src/main/java/com/swyp/meetup/service/impl/ImageServiceImpl.java
+++ b/src/main/java/com/swyp/meetup/service/impl/ImageServiceImpl.java
@@ -1,0 +1,97 @@
+package com.swyp.meetup.service.impl;
+
+import com.swyp.meetup.common.exception.ApiException;
+import com.swyp.meetup.domain.image.Image;
+import com.swyp.meetup.domain.image.ImageCode;
+import com.swyp.meetup.domain.image.ProfileStatus;
+import com.swyp.meetup.domain.member.Member;
+import com.swyp.meetup.domain.member.MemberCode;
+import com.swyp.meetup.repository.ImageRepository;
+import com.swyp.meetup.repository.MemberRepository;
+import com.swyp.meetup.service.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ImageServiceImpl implements ImageService {
+
+    private final ImageRepository imageRepository;
+    private final MemberRepository memberRepository;
+
+    @Value("${image.url}")
+    private String targetFolder;
+
+    private final String[] extensionList = {"jpg","png","jpeg"};
+
+    @Transactional
+    @Override
+    public void saveImages(Long memberId, MultipartFile profileImage, List<MultipartFile> fashionImages) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(()-> new ApiException(MemberCode.NOT_FOUND));
+
+        if(member.getNickname() == null) {
+            if(profileImage == null) throw new ApiException(ImageCode.PROFILE_IMAGE_ESSENTIAL);
+            if(fashionImages.size() < 3) throw new ApiException(ImageCode.NOT_ENOUGH_IMAGE);
+        }
+
+        save(memberId, profileImage, ProfileStatus.PROFILE);
+
+        for(MultipartFile file: fashionImages) {
+            save(memberId, file, ProfileStatus.NOT_PROFILE);
+        }
+    }
+
+    private void save(Long memberId, MultipartFile file, ProfileStatus status) {
+        try{
+            String originName = file.getOriginalFilename();
+            String changeName = imageNameGenerator(originName);
+            Path targetPath = Paths.get(targetFolder+changeName);
+            file.transferTo(targetPath);
+
+            Image image = Image.builder()
+                    .originName(originName)
+                    .storedName(changeName)
+                    .member_id(memberId)
+                    .profileStatus(status).build();
+
+            imageRepository.save(image);
+        }catch (IOException e) {
+            throw new ApiException(ImageCode.NOT_ENOUGH_IMAGE);
+        }
+
+    }
+
+    private String imageNameGenerator(String originName) {
+
+        int lastIndex = originName.lastIndexOf(".");
+        String extension = originName.substring(lastIndex);
+
+        boolean flag = isExtension(extension);
+        if(!flag) throw new ApiException(ImageCode.NOT_MATCH_EXTENSION);
+
+        LocalDate date = LocalDate.now();
+        return UUID.randomUUID() + date.toString() + extension;
+    }
+
+    private boolean isExtension(String extension) {
+        boolean flag = false;
+        for(String type: extensionList){
+            if(extension.toUpperCase().contains(type.toUpperCase())){
+                flag = true;
+                break;
+            }
+        }
+        return flag;
+    }
+}

--- a/src/main/java/com/swyp/meetup/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/swyp/meetup/service/impl/MemberServiceImpl.java
@@ -1,0 +1,49 @@
+package com.swyp.meetup.service.impl;
+
+import com.swyp.meetup.common.exception.ApiException;
+import com.swyp.meetup.domain.member.Member;
+import com.swyp.meetup.domain.member.MemberCode;
+import com.swyp.meetup.domain.member.MemberTagMap;
+import com.swyp.meetup.domain.member.dto.RestInfo;
+import com.swyp.meetup.repository.MemberRepository;
+import com.swyp.meetup.repository.MemberTagMapRepository;
+import com.swyp.meetup.service.ImageService;
+import com.swyp.meetup.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+    private final MemberTagMapRepository memberTagMapRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public boolean checkNickname(String nickname) {
+        return memberRepository.existsByNickname(nickname);
+    }
+
+    @Transactional
+    @Override
+    public void updateRestInfo(Long memberId, RestInfo restInfo) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(()-> new ApiException(MemberCode.NOT_FOUND));
+        member.setNickname(restInfo.nickname());
+
+        memberTagMapRepository.deleteAllById_MemberId(memberId);
+
+        List<MemberTagMap> memberTagMapList = new ArrayList<>();
+        for(Long tagId: restInfo.styleTagList()) {
+            memberTagMapList.add(MemberTagMap.from(memberId, tagId));
+        }
+
+        memberTagMapRepository.saveAll(memberTagMapList);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,5 @@
 
 spring:
-  autoconfigure:
-    exclude: org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
-
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://127.0.0.1:3306/meetup?serverTimezone=Asia/Seoul
@@ -18,6 +15,15 @@ spring:
       hibernate:
         format_sql: true
 
+  servlet:
+    multipart:
+      max-file-size: 2MB
+      max-request-size: 10MB
+
+  autoconfigure:
+    exclude: org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
+
+
 
 kakao:
   client_id: ${kakao_client_id}
@@ -30,3 +36,8 @@ jwt:
   refresh:
     hour: 12
   secret: ${jwt_secret}
+
+image:
+  url: ${image_url}
+
+


### PR DESCRIPTION
# 개발 사항
- 프로필 이미지, 스타일 이미지 동시 업로드 API 구현
- 닉네임 중복 체크 API 구현
- 닉네임, 스타일 태그 리스트 업데이트 및 생성 API 구현

# API
- `Get` /api/nickname/check
- `Patch` /api/members
- `Patch` /api/images

Closes #13 

